### PR TITLE
Implemented functionality for multiple clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-A resource monitoring system written in Python. The client monitors local resource usage, sending the resource usage data to the server. The server stores this data in a database, logs it, and displays it through a UI. Processes are automated using bash and Docker.
+A resource monitoring system written in Python. The client monitors local resource usage, sending the resource usage data to the server. The server stores this data in a database, logs it, and displays it through a UI. Processes are automated using bash and Docker. This program simulates multiple standalone clients sending log data to the server, which then collects and visualizes the data.
 
 ## Functionality
 
@@ -15,38 +15,38 @@ A resource monitoring system written in Python. The client monitors local resour
 
 ---
 
-Functionality: `Python`, `psutil` OR `Bash` (top, ps, etc.), `socket`
+Functionality: `Python`, `psutil` OR `Bash` (top, ps, etc.), `asyncio`
 
 ### Network
 
 - Connection between **client** (local PC) and **server** (Docker).
 - **Client**(s) can communicate with the **server** through communication with the container.
-- TCP/IP sockets or HTTP/HTTPS.
+- TCP/IP with asyncio.
 
 ---
 
-Functionality: `TCP` / `HTTP(S)`
+Functionality: `TCP`
 
 ### Server application
 
 - Runs on Docker.
 - **Server** receives resource data from multiple **clients**.
-- **Server** stores received data in SQLite database for further processing.
-- Contains a web-based interface to display visualized data.
+- **Server** stores received data in InfluxDB database for further processing.
+- Contains a web-based interface to display visualized data through InfluxDB.
 
 ---
 
-Functionality: `SQLite`, `sqlite3`, `Flask` (visualization)
+Functionality: `InfluxDB`
 
 ### Visualization
 
-- Visualization using charts/graphs based on SQLite data.
-  - Using gnuplot/chart.js, for example.
-- Occurs on the **Server**.
+- Visualization using charts/graphs based on InfluxDB data.
+  - Makes use of InfluxDB interface
+- Accessible through standalone database container endpoint
 
 ---
 
-Functionality: `Flask`, `gnuplot`, `chart.js`
+Functionality: `InfluxDB`
 
 ### Automation
 
@@ -74,11 +74,13 @@ Functionality: `Built-in logging`, `logging`
    Ensure that you're inside of the project root folder
 
 2. Run the following command:
+
 ```sh
 docker-compose up
 ```
 
 3. Reset & recreate the application entirely:
+
 ```sh
 docker-compose up --build --force-recreate
 ```
@@ -86,12 +88,35 @@ docker-compose up --build --force-recreate
 ## Debugging the application
 
 - Check Docker container information:
+
 ```sh
 docker ps
 ```
 
 - Check Docker containers network information:
+
 ```sh
 docker network inspect python-resource-monitor_monitor-network
 ```
 
+## Application flow
+
+### Client(s)
+
+Multiple client applications generate log data as part of their operation. These logs are important for understanding the behavior of the application, diagnosing problems, and analyzing performance.
+
+The client applications send their log data to a central server over TCP. TCP (Transmission Control Protocol) is a reliable, ordered, and error-checked delivery of a stream of bytes from one application to another on a network. This ensures that all log data is received correctly and in order.
+
+### Server
+
+The server receives the log data from multiple clients asynchronously. This means that the server can handle multiple connections at the same time, without waiting for one client to finish sending log data before starting to receive log data from another client.
+
+The server's job is to collect the log data from all the clients and prepare it for storage. This might involve parsing the log data, filtering it, or aggregating it in some way.
+
+### Database
+
+Once the server has collected and processed the log data, it stores the data in a database. The database provides a way to persistently store the log data, so it can be queried and analyzed later.
+
+Data can then be viewed through the User Interface provided by InfluxDB. After having logged in, the user can analyse the metrics of the individual client applications by making use of the provided dashboards.
+
+This setup allows for centralized log collection and storage, making it easier to monitor and analyze the behavior of all the client applications from a single location.

--- a/client/monitor.sh
+++ b/client/monitor.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Sleep before executing the script to simulate different connection times to the server
+sleep $STARTUP_DELAY
+
 # Open write end and read end of the pipe to the server
 exec 3<>/dev/tcp/monitor-server/8080
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "3"
 services:
-  monitor-client:
+  monitor-client-1:
     build: ./client
     networks:
       - monitor-network
@@ -8,6 +8,30 @@ services:
       - monitor-server
     command: ["/app/monitor.sh"]
     restart: always
+    environment:
+      - STARTUP_DELAY=0
+
+  monitor-client-2:
+    build: ./client
+    networks:
+      - monitor-network
+    depends_on:
+      - monitor-server
+    command: ["/app/monitor.sh"]
+    restart: always
+    environment:
+      - STARTUP_DELAY=2
+
+  monitor-client-3:
+    build: ./client
+    networks:
+      - monitor-network
+    depends_on:
+      - monitor-server
+    command: ["/app/monitor.sh"]
+    restart: always
+    environment:
+      - STARTUP_DELAY=5
 
   monitor-server:
     build: ./server

--- a/server/app/server.py
+++ b/server/app/server.py
@@ -43,6 +43,10 @@ async def initialize_monitor_client() -> MonitorInfluxClient:
     return monitorInfluxClient
 
 
+async def reset_client_data(monitorInfluxClient: MonitorInfluxClient) -> None:
+    await monitorInfluxClient.reset_data()
+
+
 async def handle_client(monitorInfluxClient: MonitorInfluxClient, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
     logger.info("New client connected")
     user_uid = str(uuid4())[:5]
@@ -111,6 +115,9 @@ if __name__ == "__main__":
     try:
         monitorInfluxClient = loop.run_until_complete(
             initialize_monitor_client())
+
+        # Reset data in InfluxDB bucket
+        loop.run_until_complete(reset_client_data(monitorInfluxClient))
         loop.run_until_complete(start_server(monitorInfluxClient))
     except KeyboardInterrupt:
         logger.info("Program interrupted")


### PR DESCRIPTION
## Changelog
- Added configuration for multiple containerized instances of the client application
- Implemented delay functionality for starting the client
- Implemented functionality for resetting database data before executing actions

## Description
Implemented functionality for the usage of multiple client applications. When starting the application, three seperate clients will be initialized, that will all make use of one server to send and then store log information. Before executing any code for the storage of logs, data from a previous session is first deleted.

Functionality for multiple clients has been implemented using Docker Compose. It was possible to make use of Kubernetes for this. But, making use of Kubernetes is not necessary for the scope and the ease of usage of this application.

## Documentation
Updated general project documentation with application flow information