### PR TITLE
Added Grafana integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,9 @@ Once the server has collected and processed the log data, it stores the data in 
 Data can then be viewed through the User Interface provided by InfluxDB. After having logged in, the user can analyse the metrics of the individual client applications by making use of the provided dashboards.
 
 This setup allows for centralized log collection and storage, making it easier to monitor and analyze the behavior of all the client applications from a single location.
+
+### Grafana
+
+To provide extra functionality for visualization, an integration with Grafana is supplied together with this application. Having configured the InfluxDB database environment, one can configure a corresponding Grafana environment by making use of the InfluxDB credentials.
+
+By making use of Grafana, you can create a real time monitoring dashboard, comparable to the dashboard offered by InfluxDB. The Grafana dashboard can be completely personalized to the user's needs.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,8 +60,20 @@ services:
       - influxdb:/var/lib/influxdb2
     networks:
       - monitor-network
+
+  grafana:
+    image: grafana/grafana:8.1.5
+    ports:
+      - "3000:3000"
+    networks:
+      - monitor-network
+    depends_on:
+      - influxdb
+    volumes:
+      - grafana-storage:/var/lib/grafana
 networks:
   monitor-network:
 
 volumes:
   influxdb:
+  grafana-storage:


### PR DESCRIPTION
## Changelog
- Added Grafana integration (seperate image + container)
- Added documentation on Grafana usage

## Description
Added Grafana integration to the project. Through the use of Grafana, you can get more detailed insights, compared to the InfluxDB dashboard. The Grafana dashboard is wholly personalized, suiting the users needs.

To set-up the Grafana integration one must follow specific steps and use specific credentials of the local InfluxDB environment. Further documentation on this will be added later.

## Documentation
Added basic Grafana documentation